### PR TITLE
Remove direct depdendency on the windows cookbook

### DIFF
--- a/.kitchen.circle.yml
+++ b/.kitchen.circle.yml
@@ -4,6 +4,7 @@ driver:
   privileged: true
 
 platforms:
+  - name: ubuntu-16.04
   - name: ubuntu-14.04
   - name: debian-8.2
   - name: centos-7

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,7 @@ provisioner:
   name: chef_zero
 
 platforms:
+  - name: ubuntu-16.04
   - name: ubuntu-14.04
   - name: debian-8.2
   - name: centos-7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 - Update dependency cookbook pins
 - Clean up new style offenses
 - Remove direct dependency on the apt cookbook
+- Remove direct dependency on the windows cookbook
 
 v1.0.0 (2016-03-03)
 -------------------

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Chef cookbook for the X2go remote desktop client.
 Requirements
 ============
 
-This cookbook requires Chef 12+.
+This cookbook requires Chef 12.6+.
 
 It currently supports Mac OS X, Windows, Ubuntu, and Red Hat/CentoS/Scientific/
 etc.

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,14 +8,13 @@ license 'apache2'
 description 'Installs/Configures x2go-client'
 long_description 'Installs/Configures x2go-client'
 version '1.0.1'
-chef_version '>= 12.1'
+chef_version '>= 12.6'
 
 source_url 'https://github.com/socrata-cookbooks/x2go-client'
 issues_url 'https://github.com/socrata-cookbooks/x2go-client/issues'
 
 depends 'xquartz', '~> 1.1'
 depends 'dmg', '~> 3.0'
-depends 'windows', '~> 2.0'
 depends 'yum-epel', '~> 1.0'
 
 supports 'mac_os_x'


### PR DESCRIPTION
This bumps the required Chef version to 12.6 (when nsis support was
added to the windows_package resource).
